### PR TITLE
Update _config.yml to include keys for gallery cards

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,11 @@ logo: notebooks/images/logos/pythia_logo-white-rtext.svg
 email: projectpythia@ucar.edu
 copyright: '2022'
 
+thumbnail: thumbnail.png
+tags:
+  domains:
+  packages:
+
 # Execute the notebooks upon build
 execute:
   execute_notebooks: cache


### PR DESCRIPTION
This lets us grab the thumbnail image for the gallery with more flexibility as well as the gallery tags (for both domain and packages).

Related to https://github.com/ProjectPythiaCookbooks/projectpythiacookbooks.github.io/issues/32